### PR TITLE
Update service.yaml

### DIFF
--- a/overops-collector/templates/service.yaml
+++ b/overops-collector/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: 6060
       protocol: TCP
-      name: collector
+      name: tcp-collector
   {{- if ne .Values.service.loadBalancerType "nlb" }}
   sessionAffinity: ClientIP
   {{- end }}


### PR DESCRIPTION
https://istio.io/v1.0/docs/setup/kubernetes/spec-requirements/
following naming standards for istio (very common k8 service mesh)

"Service ports must be named. The port names must be of the form <protocol>[-<suffix>] with http, http2, grpc, mongo, or redis as the <protocol> in order to take advantage of Istio's routing features".